### PR TITLE
Добавил проп для стилизации текста внутри кнопки

### DIFF
--- a/src/components/buttons/button.tsx
+++ b/src/components/buttons/button.tsx
@@ -158,6 +158,7 @@ const styles = StyleSheet.create((theme) => ({
     flexBasis: 'auto',
     flexGrow: 0,
     flexShrink: 1,
+    textAlign: 'center',
   },
   loader: {
     ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
- Добавил проп для стилизации текста внутри кнопки. Понадобится, например, для таких кейсов, как ниже, чтобы не надо было верстать отдельный компонент, имитирующий кнопку по размерам

<img width="1907" height="160" alt="image" src="https://github.com/user-attachments/assets/bc254ba1-4fa8-4981-86a0-eb0215fc176c" />
