### PR TITLE
feat: доработал компоненты Cell и Typograhy

### DIFF
--- a/example/src/ui/components/cell/cell.stories.tsx
+++ b/example/src/ui/components/cell/cell.stories.tsx
@@ -145,6 +145,15 @@ export const CellStory: Story = (args) => (
         onPress={fn}
       />
     </View>
+
+    <View>
+      <Typography>Оффсет для Divider'а</Typography>
+      <Cell
+        {...args}
+        leftOffset={52}
+        leadingContent={<Typography>leadingContent</Typography>}
+      />
+    </View>
   </ScrollView>
 );
 

--- a/src/components/cell/cell.tsx
+++ b/src/components/cell/cell.tsx
@@ -7,7 +7,7 @@ import type { IconProps } from '../../types';
 
 import { renderWithProps } from '../../utils';
 import { Touchable } from '../../primitives';
-import { Divider } from '../divider';
+import { Divider, type DividerProps } from '../divider';
 
 type ContainerStyleParams = {
   gap?: number;
@@ -15,7 +15,10 @@ type ContainerStyleParams = {
   paddingVertical?: number;
 };
 
-export type CellProps = ViewProps &
+const DEFAULT_PADDING_HORIZONTAL = 16;
+
+export type CellProps = Pick<DividerProps, 'leftOffset'> &
+  ViewProps &
   ContainerStyleParams & {
     disabled?: boolean;
     divider?: boolean;
@@ -30,9 +33,11 @@ export const Cell = ({
   divider = true,
   gap,
   leadingContent,
+  leftOffset = DEFAULT_PADDING_HORIZONTAL,
   paddingHorizontal,
   paddingVertical,
   rightIcon,
+  style,
   trailingContent,
   onPress,
   ...rest
@@ -49,13 +54,13 @@ export const Cell = ({
       style={styles.disabled(disabled)}
       onPress={onPress}
     >
-      <View style={containerStyles} {...rest}>
+      <View style={[containerStyles, style]} {...rest}>
         {leadingContent}
         {trailingContent}
         {renderWithProps(rightIcon)}
       </View>
 
-      {divider ? <Divider /> : null}
+      {divider ? <Divider leftOffset={leftOffset} /> : null}
     </Touchable>
   );
 };
@@ -63,7 +68,7 @@ export const Cell = ({
 const styles = StyleSheet.create({
   container: ({
     gap = 12,
-    paddingHorizontal = 16,
+    paddingHorizontal = DEFAULT_PADDING_HORIZONTAL,
     paddingVertical = 12,
   }: ContainerStyleParams) => ({
     alignItems: 'center',

--- a/src/primitives/typography.tsx
+++ b/src/primitives/typography.tsx
@@ -27,6 +27,7 @@ export const Typography = ({
 
 const styles = StyleSheet.create((theme) => ({
   typography: (variant: TypographyVariants, color: TypographyColorKeys) => ({
+    flexShrink: 1,
     color: theme.palette.all[color],
     ...theme.typography[variant],
   }),


### PR DESCRIPTION
- Добавил возможность через ячейку задать левый отступ `Divider`'а - обсуждали вчера в чате юи кита. По дефолту это величина горизонтального паддинга. На горелтехе, например, у ячеек отступ 16, а на проекте скипасс уже 52
- Для типографии добавил дефолтный `flexShrink:1`, чтобы в проектах не надо было постоянно прокидывать этот стиль там, где длинный текст

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-22 at 14 57 40" src="https://github.com/user-attachments/assets/9d7c0e89-5ce7-412e-86e5-948ff6321a46" />

<img width="1080" height="2424" alt="Screenshot_1755867657" src="https://github.com/user-attachments/assets/41e89f59-6b58-49be-9a0d-f292363c10b8" />
