### PR TITLE
feat(checkbox): добавлены цвета чекбокса при disable состоянии

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2052,7 +2052,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - UikitRn (0.2.2):
+  - UikitRn (0.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2433,7 +2433,7 @@ SPEC CHECKSUMS:
   RNSVG: 8a1054afe490b5d63b9792d7ae3c1fde8c05cdd0
   RNWorklets: b6ab2d5d0cd8f7d373d037de6bf8862e4726cf45
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  UikitRn: cbc789a59dce7353beddeb53baa04a25ed1c9f6f
+  UikitRn: f30f2ceefc6a99cdd85fbaa516ff51f4a50cf247
   Unistyles: bc5db58d33d165fb55c76e9f350b4b672ba2e4d5
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,11 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
     "prepare": "bob build",
-    "release": "release-it --only-version"
+    "release": "release-it --only-version",
+    "bootstrap": "yarn && cd example/ios && pod install && cd ../..",
+    "start": "yarn example start",
+    "ios": "yarn example ios",
+    "android": "yarn example android"
   },
   "keywords": [
     "react-native",

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -43,6 +43,7 @@ export const Checkbox = ({
   const iconColor = getIconColor({
     type,
     isError,
+    isDisabled: disabled,
   });
 
   const rippleColor = theme.palette.all[iconColor];

--- a/src/components/checkbox/utils/get-icon-color.ts
+++ b/src/components/checkbox/utils/get-icon-color.ts
@@ -1,19 +1,56 @@
-import { type IconColorKeys } from '../../../types';
+import { type IconColorFullKeys } from '../../../types';
 import { type CheckboxType } from '../types';
 
 type Props = {
   type: CheckboxType;
   isError?: boolean;
+  isDisabled?: boolean;
 };
 
-export const getIconColor = ({ type, isError }: Props): IconColorKeys => {
+type TMapColorsOutput = {
+  defaultColor: IconColorFullKeys;
+  errorColor: IconColorFullKeys;
+  defaultDisabledColor: IconColorFullKeys;
+  errorDisabledColor: IconColorFullKeys;
+};
+
+const fulfilledIconColors: TMapColorsOutput = {
+  defaultColor: 'iconAccent',
+  errorColor: 'iconNegative',
+  defaultDisabledColor: 'iconAccentDisabled',
+  errorDisabledColor: 'iconNegativeDisabled',
+};
+
+const mapColorsByType: Record<CheckboxType, TMapColorsOutput> = {
+  indeterminate: fulfilledIconColors,
+  selected: fulfilledIconColors,
+  unselected: {
+    defaultColor: 'iconTertiary',
+    errorColor: 'iconNegative',
+    defaultDisabledColor: 'iconDisabled',
+    errorDisabledColor: 'iconNegativeDisabled',
+  },
+};
+
+export const getIconColor = ({
+  type,
+  isError,
+  isDisabled,
+}: Props): IconColorFullKeys => {
+  const { errorColor, errorDisabledColor, defaultDisabledColor, defaultColor } =
+    mapColorsByType[type];
+
+  if (isError && isDisabled) {
+    return errorDisabledColor;
+  }
+
   if (isError) {
-    return 'iconNegative';
+    return errorColor;
   }
 
-  if (type === 'unselected') {
-    return 'iconTertiary';
+  if (isDisabled) {
+    return defaultDisabledColor;
   }
 
-  return 'iconAccent';
+  return defaultColor;
 };


### PR DESCRIPTION
В UI кит при дизейбл состоянии не только добавляется opacity 40% на контейнер, но и используются другие цвета

При unselected: Interactive/iconDisabled
При unselected + error: Interactive/iconNegativeDisabled

При selected/indeterminate: Interactive/iconAccentDisabled
При selected/indeterminate + error: Interactive/iconNegativeDisabled

**Preview:**
<img width="1097" height="812" alt="Снимок экрана 2025-08-27 в 14 31 29" src="https://github.com/user-attachments/assets/02cdac3a-316e-4f00-a883-a8f8083edfa4" />

Добавила несколько скриптов в package.json
```
    "bootstrap": "yarn && cd example/ios && pod install && cd ../..",
    "start": "yarn example start",
    "ios": "yarn example ios",
    "android": "yarn example android"
```
