### PR TITLE
feat(textField): добавил свойство counterMaxLength для counterSlot

### DIFF
--- a/example/src/ui/components/text-area-field/text-area-field.stories.tsx
+++ b/example/src/ui/components/text-area-field/text-area-field.stories.tsx
@@ -48,6 +48,7 @@ export const TextAreaFieldStory: Story = (args) => {
         error={error}
         helperText={'Helper Text'}
         label={'Поддерживает Helper Text'}
+        counterMaxLength={100}
         maxLength={100}
         value={value}
         onChangeText={setValue}
@@ -58,6 +59,7 @@ export const TextAreaFieldStory: Story = (args) => {
         disabled
         helperText={'Helper Text'}
         label={'Disabled'}
+        counterMaxLength={100}
         maxLength={100}
         value={value}
         onChangeText={setValue}

--- a/src/components/form-fields/text-area-field.tsx
+++ b/src/components/form-fields/text-area-field.tsx
@@ -7,10 +7,16 @@ import { TextField } from './text-field';
 export type TextAreaFieldProps = TextInputProps &
   Omit<
     FormFieldProps,
-    'fieldHeight' | 'leadingAddon' | 'state' | 'trailingAddon' | 'variant'
+    | 'fieldHeight'
+    | 'leadingAddon'
+    | 'state'
+    | 'trailingAddon'
+    | 'variant'
+    | 'children'
   > & {
     disabled?: boolean;
     error?: string;
+    counterMaxLength?: number;
   };
 
 export const TextAreaField = forwardRef<TextInputRef, TextAreaFieldProps>(

--- a/src/components/form-fields/text-field.tsx
+++ b/src/components/form-fields/text-field.tsx
@@ -21,6 +21,7 @@ export type TextFieldProps = TextInputProps &
   Omit<FormFieldProps, 'children' | 'state' | 'variant'> & {
     disabled?: boolean;
     error?: string;
+    counterMaxLength?: number;
   };
 
 export const TextField = forwardRef<TextInputRef, TextFieldProps>(
@@ -31,6 +32,7 @@ export const TextField = forwardRef<TextInputRef, TextFieldProps>(
       fieldContainerStyle,
       fieldHeight,
       helperText,
+      counterMaxLength,
       label,
       labelColor,
       labelVariant,
@@ -78,18 +80,18 @@ export const TextField = forwardRef<TextInputRef, TextFieldProps>(
 
     const counterColor = getFieldCounterColor({
       disabled,
-      maxLength: rest.maxLength,
+      maxLength: counterMaxLength,
       valueLength,
     });
 
     return (
       <FormField
         counterSlot={
-          rest.maxLength ? (
+          counterMaxLength ? (
             <Typography
               color={counterColor}
               variant={'caption1'}
-            >{`${valueLength}/${rest.maxLength}`}</Typography>
+            >{`${valueLength}/${counterMaxLength}`}</Typography>
           ) : undefined
         }
         fieldContainerStyle={fieldContainerStyle}


### PR DESCRIPTION
Сделал отдельное свойство counterMaxLength, чтобы можно ввести текст длиннее, чем указано в counterSlot