### PR TITLE
feat(text-field): добавил проп для рендера кастомных лейблов у инпутов

### DIFF
--- a/example/src/ui/components/select-field/select-field.stories.tsx
+++ b/example/src/ui/components/select-field/select-field.stories.tsx
@@ -127,6 +127,30 @@ export const SelectFieldStory: Story = (args) => {
         onSelectItem={setValue}
       />
 
+      <Typography>Поле с кастомным labelText</Typography>
+      <SelectField
+        {...args}
+        withCleanButton
+        data={data}
+        error={error}
+        renderLabelText={({ style }) => {
+          return (
+            <Typography
+              variant={'headline4'}
+              style={[style, styles.helperText]}
+            >
+              Это кастомный лейбл
+            </Typography>
+          );
+        }}
+        leadingAddon={<PlaceholderIcon color="iconTertiary" />}
+        placeholder={'Placeholder'}
+        trailingAddon={<PlaceholderIcon color="iconTertiary" />}
+        value={value}
+        onCleanItem={onCleanSelect}
+        onSelectItem={setValue}
+      />
+
       <Button
         onPress={() => {
           setError(error ? '' : 'Error message');

--- a/example/src/ui/components/text-area-field/text-area-field.stories.tsx
+++ b/example/src/ui/components/text-area-field/text-area-field.stories.tsx
@@ -112,6 +112,26 @@ export const TextAreaFieldStory: Story = (args) => {
         onChangeText={setValue}
       />
 
+      <TextAreaField
+        {...args}
+        error={error}
+        label={'Поле с кастомным labelText'}
+        renderLabelText={({ style }) => {
+          return (
+            <Typography
+              variant={'headline4'}
+              style={[style, styles.helperText]}
+            >
+              Это кастомный лейбл
+            </Typography>
+          );
+        }}
+        labelColor={'textTertiary'}
+        labelVariant={'headline3'}
+        value={value}
+        onChangeText={setValue}
+      />
+
       <Button
         onPress={() => {
           setError(error ? '' : 'Error message');

--- a/example/src/ui/components/text-field/text-field.stories.tsx
+++ b/example/src/ui/components/text-field/text-field.stories.tsx
@@ -131,6 +131,28 @@ export const TextFieldStory: Story = (args) => {
         onChangeText={setValue}
       />
 
+      <TextField
+        {...args}
+        withClean
+        counterMaxLength={100}
+        error={error}
+        leadingAddon={<PlaceholderIcon color="iconTertiary" />}
+        maxLength={100}
+        renderLabelText={({ style }) => {
+          return (
+            <Typography
+              variant={'headline4'}
+              style={[style, styles.helperText]}
+            >
+              Это кастомный лейбл
+            </Typography>
+          );
+        }}
+        trailingAddon={<PlaceholderIcon color="iconTertiary" />}
+        value={value}
+        onChangeText={setValue}
+      />
+
       <Button
         onPress={() => {
           setError(error ? '' : 'Error message');

--- a/example/src/ui/components/text-field/text-field.tsx
+++ b/example/src/ui/components/text-field/text-field.tsx
@@ -18,6 +18,7 @@ import { AlertHexagon, Delete } from '../../icons';
 export type TextFieldProps = TextFieldBaseProps & {
   withClean?: boolean;
 };
+
 export const TextField = forwardRef<TextInputRef, TextFieldProps>(
   ({ trailingAddon, withClean = false, ...rest }, ref) => {
     const inputRef = useRef<TextInputRef>(null);

--- a/src/components/form-fields/default-helper-text.tsx
+++ b/src/components/form-fields/default-helper-text.tsx
@@ -1,0 +1,16 @@
+import type { TextStyle } from 'react-native';
+
+import { Typography } from '../../primitives';
+
+export type TRenderHelperTextParams = {
+  style: TextStyle;
+  text?: string;
+};
+
+export const DefaultHelperText = ({ text, style }: TRenderHelperTextParams) => {
+  return (
+    <Typography style={style} variant={'caption1'}>
+      {text ?? ' '}
+    </Typography>
+  );
+};

--- a/src/components/form-fields/default-label-text.tsx
+++ b/src/components/form-fields/default-label-text.tsx
@@ -1,0 +1,26 @@
+import type { TextStyle } from 'react-native';
+
+import type { TypographyVariants } from '../../types';
+import { Typography } from '../../primitives';
+
+export type TRenderLabelTextParams = {
+  style: TextStyle;
+  text?: string;
+  variant?: TypographyVariants;
+};
+
+export const DefaultLabelText = ({
+  text,
+  style,
+  variant,
+}: TRenderLabelTextParams) => {
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <Typography style={style} variant={variant}>
+      {text}
+    </Typography>
+  );
+};

--- a/src/components/form-fields/form-field.tsx
+++ b/src/components/form-fields/form-field.tsx
@@ -5,28 +5,22 @@ import {
   type StyleProp,
   View,
   type ViewStyle,
-  type TextStyle,
 } from 'react-native';
 
 import { StyleSheet } from 'react-native-unistyles';
 
 import type { TypographyColorKeys, TypographyVariants } from '../../types';
 
-import { CollapseTransition, Typography } from '../../primitives';
+import { CollapseTransition } from '../../primitives';
 import { type FormFieldState, type FormFieldVariant } from './types';
-
-type TRenderHelperTextParams = {
-  style: TextStyle;
-  text?: string;
-};
-
-const DefaultHelperText = ({ text, style }: TRenderHelperTextParams) => {
-  return (
-    <Typography style={style} variant={'caption1'}>
-      {text ?? ' '}
-    </Typography>
-  );
-};
+import {
+  type TRenderHelperTextParams,
+  DefaultHelperText,
+} from './default-helper-text';
+import {
+  DefaultLabelText,
+  type TRenderLabelTextParams,
+} from './default-label-text';
 
 export type FormFieldProps = {
   children: ReactElement;
@@ -57,6 +51,7 @@ export type FormFieldProps = {
   variant?: FormFieldVariant;
   onPress?: (e: GestureResponderEvent) => void;
   renderHelperText?: ((params: TRenderHelperTextParams) => ReactElement) | null;
+  renderLabelText?: (params: TRenderLabelTextParams) => ReactElement | null;
 };
 
 export const FormField = ({
@@ -75,6 +70,7 @@ export const FormField = ({
   variant = 'default',
   onPress,
   renderHelperText = DefaultHelperText,
+  renderLabelText = DefaultLabelText,
 }: FormFieldProps) => {
   styles.useVariants({
     fieldHeight,
@@ -83,11 +79,11 @@ export const FormField = ({
 
   return (
     <Pressable testID={testID ?? 'form-field'} onPress={onPress}>
-      {label ? (
-        <Typography style={styles.label(labelColor)} variant={labelVariant}>
-          {label}
-        </Typography>
-      ) : null}
+      {renderLabelText?.({
+        style: styles.label(labelColor),
+        text: label,
+        variant: labelVariant,
+      })}
 
       <View style={[styles.inner, fieldContainerStyle]}>
         {leadingAddon}

--- a/src/components/form-fields/select-base.tsx
+++ b/src/components/form-fields/select-base.tsx
@@ -34,6 +34,7 @@ export const SelectBase = ({
   fieldContainerStyle,
   helperText,
   renderHelperText,
+  renderLabelText,
   label,
   labelColor,
   labelVariant,
@@ -78,6 +79,7 @@ export const SelectBase = ({
       fieldContainerStyle={fieldContainerStyle}
       helperText={error || helperText}
       renderHelperText={renderHelperText}
+      renderLabelText={renderLabelText}
       label={label}
       labelColor={labelColor}
       labelVariant={labelVariant}

--- a/src/components/form-fields/select-field.tsx
+++ b/src/components/form-fields/select-field.tsx
@@ -47,6 +47,7 @@ export const SelectField = forwardRef(
       fieldContainerStyle,
       helperText,
       renderHelperText,
+      renderLabelText,
       label,
       labelColor,
       labelVariant,
@@ -108,6 +109,7 @@ export const SelectField = forwardRef(
         fieldContainerStyle={fieldContainerStyle}
         helperText={helperText}
         renderHelperText={renderHelperText}
+        renderLabelText={renderLabelText}
         label={label}
         labelColor={labelColor}
         labelVariant={labelVariant}

--- a/src/components/form-fields/text-field.tsx
+++ b/src/components/form-fields/text-field.tsx
@@ -43,6 +43,7 @@ export const TextField = forwardRef<TextInputRef, TextFieldProps>(
       onChangeText,
       onFocus,
       renderHelperText,
+      renderLabelText,
       ...rest
     },
     ref
@@ -100,6 +101,7 @@ export const TextField = forwardRef<TextInputRef, TextFieldProps>(
         fieldHeight={fieldHeight}
         helperText={error || helperText}
         renderHelperText={renderHelperText}
+        renderLabelText={renderLabelText}
         label={label}
         labelColor={labelColor}
         labelVariant={labelVariant}


### PR DESCRIPTION
- На проекте появилась необходимость добавить кастомный цвет лейбла у инпутов
- Сделал по аналогии с [helperText'ом в этом МРе](https://github.com/appKODE/uikit-rn/pull/24) - через пропс для рендера кастомного лейбла
- Дефолтные хелпер текст и лейбл текст вынес в отдельный компонент, чтобы было чище

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-04 at 15 56 50" src="https://github.com/user-attachments/assets/71905d0b-70f8-49e4-8e3c-bc401dba7309" />